### PR TITLE
Add usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # fastclick-cljs-packaged
 Polyfill to remove click delays on browsers with touch UIs. Packaged for ClojureScript.
+
+## Usage
+
+Add
+
+```clojure
+[dmohs/fastclick-cljs-packaged "1.0.6"]
+```
+
+to your `project.clj` or `build.boot` file, then import FastClick into your ClojureScript namespace and enable it for the document body:
+
+```clojure
+(ns my-app
+    (:require FastClick))
+
+(js/FastClick.attach (.-body js/document))
+```


### PR DESCRIPTION
Thanks for packaging up FastClick, it's essential for mobile.

It took me a hot minute to figure out how to enable it, so I just wrote up the necessary steps and added to the readme.

Thanks!
